### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<assertj.version>3.11.1</assertj.version>
-		<junit.platform.version>1.4.0</junit.platform.version>
-		<junit.version>5.4.2</junit.version>
-		<mockito.version>2.7.6</mockito.version>
-		<pitest.version>1.4.8</pitest.version>
+		<assertj.version>3.20.2</assertj.version>
+		<junit.platform.version>1.8.0</junit.platform.version>
+		<junit.version>5.8.0</junit.version>
+		<mockito.version>3.12.4</mockito.version>
+		<pitest.version>1.7.0</pitest.version>
 	</properties>
 
 	<scm>
@@ -114,7 +114,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 				<configuration>
 					<showWarnings>true</showWarnings>
 				</configuration>
@@ -132,7 +132,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.2</version>
+				<version>0.8.6</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Bump dependency versions.

This fixes the integration with JUnit 5.8.0 and later